### PR TITLE
Implement backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore GitHub authentication credentials
+backend/creds.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/GitHub API.postman_collection.json
+++ b/GitHub API.postman_collection.json
@@ -1,0 +1,171 @@
+{
+	"info": {
+		"_postman_id": "ab0eaaa6-9557-4fd1-bcf0-643a280acd96",
+		"name": "GitHub API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Display user information",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "c3f2505a-22f5-4f84-b960-18f7cc3e3f96",
+						"exec": [
+							"pm.test(\"response must be valid and have a body\", function () {\r",
+							"     pm.response.to.be.ok;\r",
+							"     pm.response.to.be.withBody;\r",
+							"     pm.response.to.be.json;\r",
+							"});\r",
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"response contains .login property\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData).to.have.property(\"login\");\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{localhost}}/github-user-profile/users/p6l-richard",
+					"host": [
+						"{{localhost}}"
+					],
+					"path": [
+						"github-user-profile",
+						"users",
+						"p6l-richard"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Display followers for specific user",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "f220054c-6843-4dfe-a263-35c35912d058",
+						"exec": [
+							"pm.test(\"response must be valid and have a body\", function () {\r",
+							"     pm.response.to.be.ok;\r",
+							"     pm.response.to.be.withBody;\r",
+							"     pm.response.to.be.json;\r",
+							"});\r",
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"response contains .followers property\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData).to.have.property(\"followers\");\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{localhost}}/github-followers/users/p6l-richard",
+					"host": [
+						"{{localhost}}"
+					],
+					"path": [
+						"github-followers",
+						"users",
+						"p6l-richard"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Display mutual followers for specific user",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "df2b9e4f-9380-4eb2-b057-7e607a351f17",
+						"exec": [
+							"pm.test(\"response must be valid and have a body\", function () {\r",
+							"     pm.response.to.be.ok;\r",
+							"     pm.response.to.be.withBody;\r",
+							"     pm.response.to.be.json;\r",
+							"});\r",
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"response contains .mutual_followers property\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData).to.have.property(\"mutual_followers\");\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{localhost}}/github-followers/users/p6l-richard/groups/mutual",
+					"host": [
+						"{{localhost}}"
+					],
+					"path": [
+						"github-followers",
+						"users",
+						"p6l-richard",
+						"groups",
+						"mutual"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "1395b2db-0233-43c9-aea4-c55530ba3853",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "1ee75add-8e49-4f0e-ad36-1425610d4f51",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"id": "1f1b9017-150d-461e-83d7-1584b5ef616c",
+			"key": "localhost",
+			"value": "http://localhost:5000",
+			"type": "string"
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,0 +1,52 @@
+from flask import Flask, jsonify
+from github import Github
+import traceback
+import creds
+
+g = Github(creds.username, creds.password)
+
+
+def create_app(test_config=None):
+    app = Flask(__name__)
+
+    @app.route('/github-user-profile/users/<string:username>')
+    def get_user_profile(username):
+        try:
+            user_profile = g.get_user(username)
+            # flask wraps dicts automatically into successful response
+            return user_profile._rawData
+        except Exception as e:
+            print('Something went wrong because of:', e)
+            print(traceback.print_exc())
+            return {"info": "consult server log to debug"}, 500
+
+    @app.route('/github-followers/users/<string:username>')
+    def get_followers_for_user(username):
+        try:
+            fetched_followers = g.get_user(username).get_followers()
+            followers = [follower._rawData for follower in fetched_followers]
+            return jsonify({"followers": followers})
+        except Exception as e:
+            print('Something went wrong because of:', e)
+            print(traceback.print_exc())
+            return {"info": "consult server log to debug"}, 500
+
+    @app.route('/github-followers/users/<string:username>/groups/<string:follower_group>')
+    def get_followers_for_user_by_group(username, follower_group):
+        if follower_group != 'mutual' and follower_group != 'oneway':
+            return {"info": "follower group must be either 'mutual' or 'oneway'"}, 400
+        user = g.get_user(username)
+        if not user:
+            return {"info": "could not fetch user: " + username}, 400
+
+        is_mutual = True
+        if follower_group == 'oneway':
+            is_mutual = False
+
+        fetched_followers = user.get_followers()
+        followers = [
+            follower._rawData for follower in fetched_followers
+            if user.has_in_following(follower) == is_mutual]
+        return jsonify({follower_group + "_followers": followers})
+
+    return app


### PR DESCRIPTION
# PR Content
- [Tests](#tests)
    + [Positives](#positives)
    + [Negatives](#negatives)
- [Commits](#commits)
    + [test: Add API tests via Postman](#test--add-api-tests-via-postman)
    + [chore: Update .gitignore to exclude credentials file](#chore--update-gitignore-to-exclude-credentials-file)
    + [feat: Add backend routes](#feat--add-backend-routes)
---
# Tests

### Positives

`GET` Display mutual followers for specific user

*Route* `GET {{localhost}}/github-followers/users/p6l-richard/groups/mutual`

*Body*

```json

```

*Tests*

```json
pm.test("response must be valid and have a body", function () {
     pm.response.to.be.ok;
     pm.response.to.be.withBody;
     pm.response.to.be.json;
});
pm.test("Status code is 200", function () {
    pm.response.to.have.status(200);
});

pm.test("response contains .mutual_followers property", function () {
    var jsonData = pm.response.json();
    pm.expect(jsonData).to.have.property("mutual_followers");
});
```

---

`GET` Display followers for specific user

*Route* `GET` `{{localhost}}/github-followers/users/p6l-richard`

*Body*

```json

```

*Tests*

```json
pm.test("response must be valid and have a body", function () {
     pm.response.to.be.ok;
     pm.response.to.be.withBody;
     pm.response.to.be.json;
});
pm.test("Status code is 200", function () {
    pm.response.to.have.status(200);
});

pm.test("response contains .followers property", function () {
    var jsonData = pm.response.json();
    pm.expect(jsonData).to.have.property("followers");
});
```

---

---

`GET` Display User information

*Route* `GET {{localhost}}/github-user-profile/users/p6l-richard`

*Body*

```json

```

*Tests*

```json
pm.test("response must be valid and have a body", function () {
     pm.response.to.be.ok;
     pm.response.to.be.withBody;
     pm.response.to.be.json;
});
pm.test("Status code is 200", function () {
    pm.response.to.have.status(200);
});

pm.test("response contains .login property", function () {
    var jsonData = pm.response.json();
    pm.expect(jsonData).to.have.property("login");
});
```

### Negatives

# Commits

### test: Add API tests via Postman

60 min

- [x]  Display user information
- [x]  Display followers for specific user
- [x]  Display mutual followers for specific user

---

### chore: Update .gitignore to exclude credentials file

5 min

- [x]  Store GitHub authentication credentials in /backend/creds.py
- [x]  Update .gitignore to exclude above file

---

### feat: Add backend routes

45 min

- [x]  `GET /github-user-profile/users/<string:username>`

Decide if implementing a single endpoint or multiple endpoint to display follower group

Option 1: Single Endpoint

- Requires API to return `follower_group` within `/github-followers/users/<string:username>` for every follower
- I could fetch the GitHub API to check if the user pair [mutually follow each other](https://docs.github.com/en/free-pro-team@latest/rest/reference/users#check-if-a-user-follows-another-user) ⇒ this would cost me a fetch for every follower of the user delaying the response
- I could also fetch followers for all users constantly (say every day or so) and cache them into an own DB with the column `user_followers.group` — that way I could improve response time when requesting that route (downside is that I would have to query the followers for all GitHub users every day — very expensive)

Option 2: Multiple Endpoints

- Requires API to also create the endpoint `/github-followers/users/<string:username>/groups/<string:follower_group>`
- Upside is that the response for the followers is quicker and the API only responds with the slow follower categorization if explicitly requested

⇒ **Decision:** I decided to implement multiple endpoints as I think the categorization is rather expensive and I can't come up with a cheap solution. Thus, it should only be done if explicitly requested. 

- [x]  Add `GET /github-followers/users/<string:username>`
- [x]  Add follower categorization `/github-followers/users/<string:username>/groups/<string:follower_group>`